### PR TITLE
cmake: use project source paths for includes

### DIFF
--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -1,9 +1,9 @@
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/include
-			${CMAKE_SOURCE_DIR}/udc/include
-			${CMAKE_SOURCE_DIR}/config/include
-			${CMAKE_SOURCE_DIR}/function/include
-			${CMAKE_SOURCE_DIR}/gadget/include
-			${CMAKE_SOURCE_DIR}/settings/include )
+			${PROJECT_SOURCE_DIR}/udc/include
+			${PROJECT_SOURCE_DIR}/config/include
+			${PROJECT_SOURCE_DIR}/function/include
+			${PROJECT_SOURCE_DIR}/gadget/include
+			${PROJECT_SOURCE_DIR}/settings/include )
 
 SET( BASE_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/src/backend.c

--- a/source/gadget/CMakeLists.txt
+++ b/source/gadget/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/include
-			${CMAKE_SOURCE_DIR}/function/include
-			${CMAKE_SOURCE_DIR}/config/include )
+			${PROJECT_SOURCE_DIR}/function/include
+			${PROJECT_SOURCE_DIR}/config/include )
 
 SET( GADGET_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/src/gadget.c


### PR DESCRIPTION
replaced CMAKE_SOURCE_DIR with PROJECT_SOURCE_DIR

**Issue:**
   Using `gt` project as submodule in super project with `add_subdirectory`
   During compilation `base` and `gadget` includes not found because `CMAKE_SOURCE_DIR` points on super project directory, not `gt`

**Solution:**
  Use either `PROJECT_SOURCE_DIR` or `gt_SOURCE_DIR` which is the same (ref [here](https://cmake.org/cmake/help/v2.8.1/cmake.html#variable:PROJECT_SOURCE_DIR)).
  I replace to `PROJECT_SOURCE_DIR` because if `PROJECT(gt)` will changed somehow, it will not affect other scripts.
   