### PR TITLE
Add inquiry_string attribute

### DIFF
--- a/source/function/src/function_libusbg.c
+++ b/source/function/src/function_libusbg.c
@@ -168,6 +168,7 @@ int gt_print_function_libusbg(usbg_function *f, int opts)
 			fprintf(stdout, "      nofua\t\t%d\n", attrs->luns[i]->nofua);
 			fprintf(stdout, "      removable\t\t%d\n", attrs->luns[i]->removable);
 			fprintf(stdout, "      file\t\t%s\n", attrs->luns[i]->file);
+			fprintf(stdout, "      inquiry_string\t%s\n", attrs->luns[i]->inquiry_string);
 		}
 		break;
 	}


### PR DESCRIPTION
# Add "inquiry_string" to LUN attributes
## What is inquiry_string in LUN attributes?
Inquiry string is a name of LUN which used in SCSI inquiry

### For example: 
#### Without inquiry_string (as now)
```
[timesnap] usb 1-9: new high-speed USB device number 22 using xhci_hcd
[timesnap] usb 1-9: New USB device found, idVendor=1d6b, idProduct=0104, bcdDevice= 0.01
[timesnap] usb 1-9: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[timesnap] usb 1-9: Product: Bar Gadget
[timesnap] usb 1-9: Manufacturer: Foo Inc.
[timesnap] usb 1-9: SerialNumber: 0123456789
[timesnap] usb-storage 1-9:1.0: USB Mass Storage device detected
[timesnap] scsi host6: usb-storage 1-9:1.0
[timesnap] scsi 6:0:0:0: Direct-Access     Linux    File-Stor Gadget 0607 PQ: 0 ANSI: 2
[timesnap] scsi 6:0:0:1: CD-ROM            Linux    File-Stor Gadget 0607 PQ: 0 ANSI: 2
```
#### Without inquiry_string (after merging this PR)
```
[timesnap] usb 1-9: new high-speed USB device number 23 using xhci_hcd
[timesnap] usb 1-9: New USB device found, idVendor=1d6b, idProduct=0104, bcdDevice= 0.01
[timesnap] usb 1-9: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[timesnap] usb 1-9: Product: Bar Gadget
[timesnap] usb 1-9: Manufacturer: Foo Inc.
[timesnap] usb 1-9: SerialNumber: 0123456789
[timesnap] usb-storage 1-9:1.0: USB Mass Storage device detected
[timesnap] scsi host6: usb-storage 1-9:1.0
[timesnap] scsi 6:0:0:0: Direct-Access     Non-empt y                     PQ: 0 ANSI: 2
[timesnap] scsi 6:0:0:1: CD-ROM            Empty                          PQ: 0 ANSI: 2
```